### PR TITLE
ci: add basic CI with Github/action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,6 +55,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Create github release 
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,3 +80,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           file: ${{ steps.download.outputs.download-path }}
+          release_id: ${{ steps.create_release.outputs.id }}
+          overwrite: true
+          verbose: env.ACTIONS_STEP_DEBUG 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,7 +58,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           draft: ${{ !startsWith(github.ref, 'refs/tags/v') }}
           prerelease: false
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,4 +82,4 @@ jobs:
           file: ${{ steps.download.outputs.download-path }}
           release_id: ${{ steps.create_release.outputs.id }}
           overwrite: true
-          verbose: env.ACTIONS_STEP_DEBUG 
+          verbose: env.ACTIONS_STEP_DEBUG

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,75 @@
+name: main
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs: 
+  build-net:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+
+      - name: Create Build Directory
+        run: mkdir dist-net,dist-netcore
+
+      - name: Build .Net version
+        run: | 
+          msbuild.exe SourcetrailDotnetIndexer.sln /t:SourcetrailDotnetIndexer /nologo /p:platform="x64" /p:configuration="Release" /p:OutputPath="..\dist-net"
+
+      - name: Build .Net Core version
+        run: dotnet publish SourcetrailDotnetCoreIndexer\SourcetrailDotnetCoreIndexer.csproj -c Release -o "dist-netcore" -r win-x64 --nologo --self-contained false
+
+      - name: Packing .Net artifact
+        run: |
+          7z a SourcetrailDotnetIndexer-win-x64.zip .\dist-net\*
+
+      - name: Packing .Net Core artifact
+        run: |
+          7z a SourcetrailDotnetCoreIndexer-win-x64.zip .\dist-netcore\*
+
+      - name: Uploading artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: BUILD
+          path: ./*-win-x64.zip
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build-net
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      - name: Create github release 
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+          prerelease: false
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: BUILD
+          path: BUILD
+
+      - name: Uploading artifacts to release
+        uses: alexellis/upload-assets@0.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_paths: '["./BUILD/*"]'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,11 +69,12 @@ jobs:
           path: ./BUILD
 
       - name: 'Echo download path'
+        if: env.ACTIONS_STEP_DEBUG 
         run: echo ${{steps.download.outputs.download-path}}
 
       - name: Uploading artifacts to release
-        uses: alexellis/upload-assets@0.2.2
+        uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          asset_paths: '["./BUILD/*"]'
+          file: ${{ steps.download.outputs.download-path }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,9 +63,13 @@ jobs:
           prerelease: false
 
       - uses: actions/download-artifact@v2
+        id: download
         with:
           name: BUILD
-          path: BUILD
+          path: ./BUILD
+
+      - name: 'Echo download path'
+        run: echo ${{steps.download.outputs.download-path}}
 
       - name: Uploading artifacts to release
         uses: alexellis/upload-assets@0.2.2


### PR DESCRIPTION
Hello, 

This PR add a basic CI & CD using [Github actions](https://docs.github.com/en/actions).

What does it do: 
- for basic commit and PR on main => build validation + release artifact at the end of the pipeline 
- for tag on main => build and create a draft release (with artifact), that you can customise 

Example [here](https://github.com/Herve-M/SourcetrailDotnetIndexer/releases/tag/main-895ea7f5)

Tell me if you prefer/need another workflow or want me to squash everything,
Hervé